### PR TITLE
Update smartcaptcha.ts

### DIFF
--- a/src/utils/smartcaptcha.ts
+++ b/src/utils/smartcaptcha.ts
@@ -2,7 +2,7 @@ import type { SubscribeEvent, Token, WidgetId, CaptchaSubscriptionEventCallback 
 
 class SmartCaptchaUtils
 {
-    readonly SCRIPT_RENDER_ONLOAD_SRC = 'https://smartcaptcha.yandexcloud.net/captcha.js?render=onload'
+    readonly SCRIPT_RENDER_ONLOAD_SRC = 'https://smartcaptcha.cloud.yandex.ru/captcha.js?render=onload'
 
     execute (widgetID?: WidgetId) {
         window.smartCaptcha?.execute(widgetID)


### PR DESCRIPTION
Our colleagues at Yandex say that for the captcha to work more reliably for users, the URL needs to be changed.

The documentation already indicates a new address: https://yandex.cloud/ru/docs/smartcaptcha/concepts/widget-methods